### PR TITLE
Support singualr unit

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,7 +2,7 @@ class Message < ApplicationRecord
   belongs_to :resource, primary_key: 'uri', foreign_key: 'resource_uri'
 
   validates :resource_uri, presence: true
-  validates :resource_unit, presence: true, inclusion: { in: %w(daily hourly daily,hourly) }
+  validates :resource_unit, presence: true, inclusion: { in: %w(singular daily hourly) }
   validates :resource_time, presence: true, numericality: { only_integer: true }
   validates :resource_timezone, presence: true, format: { with: /\A[+-]\d\d:\d\d\z/ }
   validates :payload, json: true

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -3,7 +3,7 @@
 class Resource < ApplicationRecord
   has_many :messages, primary_key: 'uri', foreign_key: 'resource_uri'
 
-  validates :unit, inclusion: { in: %w(daily hourly daily,hourly) } # monthly, streaming support?
+  validates :unit, inclusion: { in: %w(singular daily hourly) } # monthly, streaming support?
   validates :timezone, presence: true, format: { with: /\A[+-]\d\d:\d\d\z/ }
 
   before_save :set_default

--- a/app/serializers/aggregated_resource_each_serializer.rb
+++ b/app/serializers/aggregated_resource_each_serializer.rb
@@ -10,7 +10,7 @@ class AggregatedResourceEachSerializer < ActiveModel::Serializer
     end
     property :unit do
       key :type, :string
-      key :description, "'daily' or 'hourly', and 'daily,hourly'"
+      key :description, "'singular' or 'daily' or 'hourly', or their combinations such as 'daily,hourly', 'daily,hourly,singular'"
     end
     property :timezone do
       key :type, :string

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -57,7 +57,7 @@ class MessageSerializer < ActiveModel::Serializer
     end
     property :resource_unit do
       key :type, :string
-      key :description, 'Time unit of resource to monitor such as daily, or hourly'
+      key :description, 'Time unit of resource to monitor such as singular, daily, or hourly'
     end
     property :resource_time do
       key :type, :integer

--- a/app/serializers/resource_each_serializer.rb
+++ b/app/serializers/resource_each_serializer.rb
@@ -11,7 +11,7 @@ class ResourceEachSerializer < ActiveModel::Serializer
       schema do
         property :unit do
           key :type, :string
-          key :description, "'daily' or 'hourly'"
+          key :description, "'singualr' or 'daily' or 'hourly'"
         end
         property :consumable do
           key :type, :boolean

--- a/app/serializers/resource_serializer.rb
+++ b/app/serializers/resource_serializer.rb
@@ -63,7 +63,7 @@ class ResourceSerializer < ActiveModel::Serializer
     end
     property :unit do
       key :type, :string
-      key :description, 'Time unit of resource to monitor such as daily, or hourly'
+      key :description, 'Time unit of resource to monitor such as singular, daily, or hourly'
     end
     property :timezone do
       key :type, :string

--- a/db/schemas/resources.schema
+++ b/db/schemas/resources.schema
@@ -2,7 +2,7 @@ create_table "resources", create_table_options do |t|
 
   t.text      "description", limit: 16777215
   t.string    "uri", collation: 'latin1_swedish_ci', null: false
-  t.string    "unit", collation: 'latin1_swedish_ci', null: false # daily, hourly
+  t.string    "unit", collation: 'latin1_swedish_ci', null: false # singular, daily, hourly
   t.string    "timezone", collation: 'latin1_swedish_ci', null: false # %:z format such as +00:00, +09:00
   t.integer   "span_in_days" # duration to monitor
 

--- a/doc/api/v1/resources.md
+++ b/doc/api/v1/resources.md
@@ -1,5 +1,5 @@
 ## GET /api/v1/aggregated_resources
-Get aggregated resources required to be monitored (i.e., consumable = true and notifiable = false).<br/><br/>`resource_prefix` query parameter is required. Each returned resource has `uri`, `unit`, `timezone`, `span_in_days` parameters. Note that the `unit` paramter would be `daily,hourly` in addition to `hourly`, `daily`.<br/><br/>FYI: Aggregation is operated as following SQL: `SELECT uri, GROUP_CONCAT(DISTINCT(unit) order by unit) AS unit, timezone, MAX(span_in_days) AS span_in_days GROUP BY uri`<br/>
+Get aggregated resources required to be monitored (i.e., consumable = true and notifiable = false).<br/><br/>`resource_prefix` query parameter is required. Each returned resource has `uri`, `unit`, `timezone`, `span_in_days` parameters. `unit` is `singular` or `daily` or `hourly`, or their combinations such as `daily,hourly` or `daily,hourly,singular`.<br/><br/>FYI: Aggregation is operated as following SQL: `SELECT uri, GROUP_CONCAT(DISTINCT(unit) order by unit) AS unit, timezone, MAX(span_in_days) AS span_in_days GROUP BY uri`<br/>
 
 ### Example
 
@@ -7,7 +7,7 @@ Get aggregated resources required to be monitored (i.e., consumable = true and n
 ```
 GET /api/v1/aggregated_resources?uri_prefix=hdfs://localhost HTTP/1.1
 Accept: application/json
-Authorization: ee5f61b0843989203187e40210851386
+Authorization: 826dc974972f2232b3768ed590c34e4a
 Content-Length: 0
 Content-Type: application/json
 Host: triglav.analytics.mbga.jp
@@ -17,19 +17,19 @@ Host: triglav.analytics.mbga.jp
 ```
 HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
-Content-Length: 190
+Content-Length: 199
 Content-Type: application/json; charset=utf-8
-ETag: W/"79d1aaf9b1b11e2f2dfe720e77957593"
+ETag: W/"9a3d4c5329bde6ef217bf86390886968"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 7582a415-5e40-420c-8b5f-679b0c5d6dd0
-X-Runtime: 0.051705
+X-Request-Id: 2bc1d59c-2e45-46c6-814d-345436fe761a
+X-Runtime: 0.050161
 X-XSS-Protection: 1; mode=block
 
 [
   {
     "uri": "hdfs://localhost/aaa.csv.gz",
-    "unit": "daily,hourly",
+    "unit": "daily,hourly,singular",
     "timezone": "+09:00",
     "span_in_days": 48
   },
@@ -51,7 +51,7 @@ Get resource index<br/>
 ```
 GET /api/v1/resources?uri_prefix=hdfs://localhost HTTP/1.1
 Accept: application/json
-Authorization: 169dd3b38b9d692ba07aa1f1abc86805
+Authorization: 02dc1e20aab65b73cb66f81a0253211b
 Content-Length: 0
 Content-Type: application/json
 Host: triglav.analytics.mbga.jp
@@ -61,16 +61,24 @@ Host: triglav.analytics.mbga.jp
 ```
 HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
-Content-Length: 770
+Content-Length: 901
 Content-Type: application/json; charset=utf-8
-ETag: W/"22f1d28635b1a79546858e351068eb44"
+ETag: W/"241499a51f690e3c48845461c5b66a19"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 154c2202-4335-4cd1-a009-607bed6e9b45
-X-Runtime: 0.011445
+X-Request-Id: 5e46146d-82c6-4475-a3b0-1aad1e3ba5f7
+X-Runtime: 0.010587
 X-XSS-Protection: 1; mode=block
 
 [
+  {
+    "uri": "hdfs://localhost/aaa.csv.gz",
+    "unit": "singular",
+    "timezone": "+09:00",
+    "span_in_days": 32,
+    "consumable": true,
+    "notifiable": false
+  },
   {
     "uri": "hdfs://localhost/aaa.csv.gz",
     "unit": "daily",
@@ -129,9 +137,9 @@ Get a resource
 
 #### Request
 ```
-GET /api/v1/resources/273 HTTP/1.1
+GET /api/v1/resources/282 HTTP/1.1
 Accept: application/json
-Authorization: 4cfae14e4171a5e03e93d10b0f8c21bf
+Authorization: de98e2af91eaa43c5a24e8f405e849be
 Content-Length: 0
 Content-Type: application/json
 Host: triglav.analytics.mbga.jp
@@ -143,15 +151,15 @@ HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 251
 Content-Type: application/json; charset=utf-8
-ETag: W/"9bc93a7476c8e9caea1bae864aaf4680"
+ETag: W/"f626e14aff79578013bb9629ebd53f16"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 92e33a33-ed9b-4547-9962-99bf300dea89
-X-Runtime: 0.010178
+X-Request-Id: f463c979-e288-4e64-a0d9-283181e6205c
+X-Runtime: 0.008709
 X-XSS-Protection: 1; mode=block
 
 {
-  "id": 273,
+  "id": 282,
   "description": "MyString",
   "uri": "hdfs://localhost/aaa.csv.gz",
   "unit": "daily",
@@ -159,8 +167,8 @@ X-XSS-Protection: 1; mode=block
   "span_in_days": 32,
   "consumable": true,
   "notifiable": false,
-  "created_at": "2016-12-16T20:40:48.000+09:00",
-  "updated_at": "2016-12-16T20:40:48.000+09:00"
+  "created_at": "2017-01-04T10:26:46.000+09:00",
+  "updated_at": "2017-01-04T10:26:46.000+09:00"
 }
 ```
 
@@ -173,7 +181,7 @@ Create a resource
 ```
 POST /api/v1/resources HTTP/1.1
 Accept: application/json
-Authorization: 41b0952fd36f505d65874be910c34a6c
+Authorization: 8463e8b60ab2eb6d55246b56bb65e1dc
 Content-Length: 173
 Content-Type: application/json
 Host: triglav.analytics.mbga.jp
@@ -196,15 +204,15 @@ HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 260
 Content-Type: application/json; charset=utf-8
-ETag: W/"25fd71376669d6fef029f224702e00e1"
+ETag: W/"d2b9adc21558559d1c7204e89e1c0767"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: c7f8cfa6-bf82-46c8-93c9-28928051fda7
-X-Runtime: 0.010359
+X-Request-Id: cd96544b-389a-4112-8f01-d63cca3dff7e
+X-Runtime: 0.009400
 X-XSS-Protection: 1; mode=block
 
 {
-  "id": 275,
+  "id": 284,
   "description": "MyString",
   "uri": "hdfs://localhost/path/to/file.csv.gz",
   "unit": "daily",
@@ -212,8 +220,8 @@ X-XSS-Protection: 1; mode=block
   "span_in_days": 32,
   "consumable": true,
   "notifiable": false,
-  "created_at": "2016-12-16T20:40:48.000+09:00",
-  "updated_at": "2016-12-16T20:40:48.000+09:00"
+  "created_at": "2017-01-04T10:26:46.000+09:00",
+  "updated_at": "2017-01-04T10:26:46.000+09:00"
 }
 ```
 
@@ -224,15 +232,15 @@ Update a resource
 
 #### Request
 ```
-PUT /api/v1/resources/276 HTTP/1.1
+PUT /api/v1/resources/285 HTTP/1.1
 Accept: application/json
-Authorization: 6e9cdfac15c78d07fa1b2da9ed048547
+Authorization: 3784c05e479a66a86d03c4dcde7d4fba
 Content-Length: 170
 Content-Type: application/json
 Host: triglav.analytics.mbga.jp
 
 {
-  "id": 276,
+  "id": 285,
   "description": "MyString",
   "uri": "hdfs://localhost/path/to/file.csv.gz",
   "unit": "daily",
@@ -249,15 +257,15 @@ HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 260
 Content-Type: application/json; charset=utf-8
-ETag: W/"f307e9f75857bfd92f7fdff8cb959491"
+ETag: W/"a912e2ea8fb71d054456ff7201d99cec"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 4a3a333f-37f7-49c9-af10-2029054e5801
-X-Runtime: 0.009258
+X-Request-Id: 2f7f2d77-fc8e-4c02-81eb-eeb7c8330f49
+X-Runtime: 0.011057
 X-XSS-Protection: 1; mode=block
 
 {
-  "id": 276,
+  "id": 285,
   "description": "MyString",
   "uri": "hdfs://localhost/path/to/file.csv.gz",
   "unit": "daily",
@@ -265,8 +273,8 @@ X-XSS-Protection: 1; mode=block
   "span_in_days": 32,
   "consumable": true,
   "notifiable": false,
-  "created_at": "2016-12-16T20:40:48.000+09:00",
-  "updated_at": "2016-12-16T20:40:48.000+09:00"
+  "created_at": "2017-01-04T10:26:46.000+09:00",
+  "updated_at": "2017-01-04T10:26:46.000+09:00"
 }
 ```
 
@@ -277,9 +285,9 @@ Delete a resource
 
 #### Request
 ```
-DELETE /api/v1/resources/278 HTTP/1.1
+DELETE /api/v1/resources/287 HTTP/1.1
 Accept: application/json
-Authorization: fcdb0283a580bd447d133dbad2ef01ed
+Authorization: ff85989bdc11006afba650d2ec56d3cf
 Content-Length: 0
 Content-Type: application/json
 Host: triglav.analytics.mbga.jp
@@ -291,7 +299,7 @@ HTTP/1.1 204
 Cache-Control: no-cache
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 1c82fcd2-c4b7-4518-bd39-fe5c751497c3
-X-Runtime: 0.007772
+X-Request-Id: 8f2e5eac-7fc6-4a63-bcdc-c8af44d12d9e
+X-Runtime: 0.032710
 X-XSS-Protection: 1; mode=block
 ```

--- a/spec/requests/api/v1/resources_spec.rb
+++ b/spec/requests/api/v1/resources_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Resource resources', :type => :request do
 
   let(:resources) do
     [
+      FactoryGirl.create(:resource, uri: 'hdfs://localhost/aaa.csv.gz', unit: 'singular',  span_in_days: 32, consumable: true, notifiable: false),
       FactoryGirl.create(:resource, uri: 'hdfs://localhost/aaa.csv.gz', unit: 'daily',  span_in_days: 32, consumable: true, notifiable: false),
       FactoryGirl.create(:resource, uri: 'hdfs://localhost/aaa.csv.gz', unit: 'hourly', span_in_days: 16, consumable: true, notifiable: false),
       FactoryGirl.create(:resource, uri: 'hdfs://localhost/aaa.csv.gz', unit: 'hourly', span_in_days: 48, consumable: true, notifiable: false),
@@ -45,7 +46,8 @@ RSpec.describe 'Resource resources', :type => :request do
       "Get aggregated resources required to be monitored (i.e., consumable = true and notifiable = false).<br/>" \
       "<br/>" \
       "`resource_prefix` query parameter is required. " \
-      "Each returned resource has `uri`, `unit`, `timezone`, `span_in_days` parameters. Note that the `unit` paramter would be `daily,hourly` in addition to `hourly`, `daily`.<br/>" \
+      "Each returned resource has `uri`, `unit`, `timezone`, `span_in_days` parameters. " \
+      "`unit` is `singular` or `daily` or `hourly`, or their combinations such as `daily,hourly` or `daily,hourly,singular`.<br/>" \
       "<br/>" \
       "FYI: Aggregation is operated as following SQL: " \
       "`SELECT uri, GROUP_CONCAT(DISTINCT(unit) order by unit) AS unit, timezone, MAX(span_in_days) AS span_in_days GROUP BY uri`<br/>" \
@@ -66,7 +68,7 @@ RSpec.describe 'Resource resources', :type => :request do
 
       expect(response.status).to eq 200
       expect(json.size).to eq 2
-      expect(json[0]['unit']).to eq 'daily,hourly'
+      expect(json[0]['unit']).to eq 'daily,hourly,singular'
 
     end
   end
@@ -91,7 +93,7 @@ RSpec.describe 'Resource resources', :type => :request do
       json = JSON.parse(response.body)
 
       expect(response.status).to eq 200
-      expect(json.size).to eq 6
+      expect(json.size).to eq 7
 
     end
   end


### PR DESCRIPTION
singular resources is a resource to monitor entire, not partial daily or hourly paritition.
This is prepared especailly to monitor vertica tables which do not have `d` or `t` columns.

triglav-agent-vertica, and triglav-agent-hdfs already supports the singular unit.